### PR TITLE
STREET-1800:

### DIFF
--- a/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/MeasurementObservation.cs
+++ b/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/MeasurementObservation.cs
@@ -193,28 +193,28 @@ namespace StreetSmartArcGISPro.Overlays.Measurement
           Color outerColorLine = Color.DarkGray;
           IObservationLines observationLines = _measurementPoint.Measurement.ObservationLines;
 
-          if (observationLines.ActiveObservation + 1 == _measurementPoint.PointId)
-          {
-            if (observationLines.RecordingId == ImageId)
-            {
-              outerColorLine = observationLines.Color;
-            }
-            else
-            {
-              switch (LineNumber)
-              {
-                case 0:
-                  outerColorLine = Color.Blue;
-                  break;
-                case 1:
-                  outerColorLine = Color.Yellow;
-                  break;
-                case 2:
-                  outerColorLine = Color.Red;
-                  break;
-              }
-            }
-          }
+          //if (observationLines.ActiveObservation + 1 == _measurementPoint.PointId)
+          //{
+          //  if (observationLines.RecordingId == ImageId)
+          //  {
+          //    outerColorLine = observationLines.Color;
+          //  }
+          //  else
+          //  {
+          //    switch (LineNumber)
+          //    {
+          //      case 0:
+          //        outerColorLine = Color.Blue;
+          //        break;
+          //      case 1:
+          //        outerColorLine = Color.Yellow;
+          //        break;
+          //      case 2:
+          //        outerColorLine = Color.Red;
+          //        break;
+          //    }
+          //  }
+          //}
 
           CIMColor cimOuterColorLine = ColorFactory.Instance.CreateColor(Color.FromArgb(255, outerColorLine));
           CIMLineSymbol cimOuterLineSymbol = SymbolFactory.Instance.DefaultLineSymbol;


### PR DESCRIPTION
STREET-1800: 
- Added a workaround fix for the observation lines, but this fix doesn't work always. Have to solve this one in the api
- Clean up code little bit: removed the drawing of the innerObservation Line (not used in StreetSmart, only used in GlobeSpotter)