### PR TITLE
ESRI-162 - Crash Fix

### DIFF
--- a/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/Measurement.cs
+++ b/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/Measurement.cs
@@ -693,6 +693,7 @@ namespace StreetSmartArcGISPro.Overlays.Measurement
             }
             else if (geometry is MapPoint or Multipoint)
             {
+              // Note: If future support for the Multipoint type of FeatureCollection is needed, this section should be modified to handle Multipoint geometry accordingly.
               MapPoint point = (Count >= 1 ? this.ElementAt(0).Value.Point : null) ?? geometry switch
               {
                 MapPoint mapPoint => mapPoint,

--- a/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/Measurement.cs
+++ b/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/Measurement.cs
@@ -338,7 +338,7 @@ namespace StreetSmartArcGISPro.Overlays.Measurement
           double modifierFactor = spatialReference?.Unit?.ConversionFactor ?? 1.0;
           //GC: adding if statement for features missing z reference since it gets put underground
           if (spatialReference?.ZUnit == null && (((Count >= 2 || geoPointCount >= 2) && geometryType == ArcGISGeometryType.Polyline)
-          || geometryType == ArcGISGeometryType.Point || geometryType == ArcGISGeometryType.Polygon))
+          || geometryType == ArcGISGeometryType.Point || geometryType == ArcGISGeometryType.Polygon || geometryType == ArcGISGeometryType.Multipoint))
           {
             zScale = 1 / modifierFactor;
           }
@@ -360,6 +360,7 @@ namespace StreetSmartArcGISPro.Overlays.Measurement
             }
 
             break;
+          case ArcGISGeometryType.Multipoint:
           case ArcGISGeometryType.Polygon:
           case ArcGISGeometryType.Polyline:
 
@@ -690,9 +691,15 @@ namespace StreetSmartArcGISPro.Overlays.Measurement
 #endif
               }
             }
-            else if (geometry is MapPoint mapPoint)
+            else if (geometry is MapPoint or Multipoint)
             {
-              MapPoint point = Count >= 1 ? this.ElementAt(0).Value.Point : mapPoint;
+              MapPoint point = (Count >= 1 ? this.ElementAt(0).Value.Point : null) ?? geometry switch
+              {
+                MapPoint mapPoint => mapPoint,
+                Multipoint multipoint => multipoint.Points.Count >= 1 ? multipoint.Points[0] : null,
+                _ => null
+              };
+
               double conversionFactor = spatialReference?.ZUnit?.ConversionFactor ?? 1.0;
               double z = conversionFactor * (point?.Z ?? 0);
               if (spatialReference.ZUnit == null || srs == null)

--- a/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/MeasurementList.cs
+++ b/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/MeasurementList.cs
@@ -135,6 +135,7 @@ namespace StreetSmartArcGISPro.Overlays.Measurement
         switch (geometryType)
         {
           case ArcGISGeometryType.Point:
+          case ArcGISGeometryType.Multipoint:
             if (GlobeSpotterConfiguration.MeasurePoint)
             {
               measurementGeometryType = MeasurementGeometryType.Point;
@@ -299,7 +300,7 @@ namespace StreetSmartArcGISPro.Overlays.Measurement
         ArcGISGeometryType geometryType = geometry?.GeometryType ?? ArcGISGeometryType.Unknown;
 
         if (geometryType == ArcGISGeometryType.Point || geometryType == ArcGISGeometryType.Polygon ||
-            geometryType == ArcGISGeometryType.Polyline)
+            geometryType == ArcGISGeometryType.Polyline || geometryType == ArcGISGeometryType.Multipoint)
         {
           if (measurement?.IsGeometryType(geometryType) ?? false)
           {

--- a/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/MeasurementList.cs
+++ b/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Overlays/Measurement/MeasurementList.cs
@@ -134,6 +134,7 @@ namespace StreetSmartArcGISPro.Overlays.Measurement
 
         switch (geometryType)
         {
+          // Note: If future support for the Multipoint type of FeatureCollection is needed, this section should be modified to handle Multipoint geometry accordingly.
           case ArcGISGeometryType.Point:
           case ArcGISGeometryType.Multipoint:
             if (GlobeSpotterConfiguration.MeasurePoint)


### PR DESCRIPTION
ESRI-162 - Fixed not to crash occasionally when creating a new point, and fix to handle a wrong returning value from the ESRI method GetCurrentSketchAsync();