### PR TITLE
ESRI-276 - Bug fixed with not showing all available coordinate systems

### DIFF
--- a/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Configuration/Remote/SpatialReference/SpatialReferenceDictionary.cs
+++ b/client-side/C#/StreetSmartArcGISPro/StreetSmartArcGISPro/Configuration/Remote/SpatialReference/SpatialReferenceDictionary.cs
@@ -63,6 +63,11 @@ namespace StreetSmartArcGISPro.Configuration.Remote.SpatialReference
             _spatialReferences = new SpatialReferenceDictionary();
             foreach (var item in spatialReferences)
             {
+              if (_spatialReferences.Contains(item.SRSName))
+              {
+                EventLog.Write(EventLog.EventType.Error, $"Street Smart: (SpatialReferenceList.cs) (Instance) An item with the same key has already been added. Key: {item.SRSName}");
+                continue; 
+              }
               _spatialReferences.Add(item);
             }
           }


### PR DESCRIPTION
An additional check has been added so that if a spatial reference with the same EPSG code already exists, it logs this information and skips that element.